### PR TITLE
Quitar emojis del escritorio CarlOS

### DIFF
--- a/os/index.html
+++ b/os/index.html
@@ -26,7 +26,7 @@
   <div class="window" id="win-mapa" data-nombre="mapa">
     <div class="titlebar"><span>📁 C:\CarlOS\ — mapa</span><button class="tb-btn" aria-label="minimizar">_</button></div>
     <div class="win-inset">
-      <span class="tree-root">🖥 C:\CarlOS\</span>
+      <span class="tree-root">C:\CarlOS\</span>
       <button class="tree-item" data-abre="perfil">📂 perfil</button>
       <button class="tree-item" data-abre="musica">📂 música</button>
       <button class="tree-item" data-abre="mastodon">📂 mastodon</button>
@@ -38,7 +38,7 @@
 
   <!-- perfil -->
   <div class="window" id="win-perfil" data-nombre="perfil" hidden>
-    <div class="titlebar"><span>👤 perfil — carlos.exe</span><button class="tb-btn" data-close aria-label="cerrar">×</button></div>
+    <div class="titlebar"><span>perfil — carlos.exe</span><button class="tb-btn" data-close aria-label="cerrar">×</button></div>
     <div class="perfil-row">
       <strong class="perfil-nombre">CarlOS</strong>
       <span class="perfil-sub">2005 · he/they/she · Zaragoza · DE @ UNIZAR</span>
@@ -48,7 +48,7 @@
 
   <!-- música -->
   <div class="window" id="win-musica" data-nombre="música" hidden>
-    <div class="titlebar"><span>🎵 música — reproductor.exe</span><button class="tb-btn" data-close aria-label="cerrar">×</button></div>
+    <div class="titlebar"><span>música — reproductor.exe</span><button class="tb-btn" data-close aria-label="cerrar">×</button></div>
     <div class="musica-row">
       <img class="caratula sunken" id="musica-caratula" src="/carlos-design-system/assets/gato.escuchando.gif" alt="carátula">
       <div class="marquee-box sunken">
@@ -65,7 +65,7 @@
 
   <!-- mastodon -->
   <div class="window" id="win-mastodon" data-nombre="mastodon" hidden>
-    <div class="titlebar purple"><span>🐘 mastodon — @copaco</span><button class="tb-btn" data-close aria-label="cerrar">×</button></div>
+    <div class="titlebar purple"><span>mastodon — @copaco</span><button class="tb-btn" data-close aria-label="cerrar">×</button></div>
     <div class="win-inset">
       <div class="bubble-mastodon" id="mastodon-toot">cargando último toot…</div>
       <a class="responder" href="https://mastodon.social/@copaco" target="_blank" rel="noopener">responder en mastodon.social ↗</a>
@@ -74,7 +74,7 @@
 
   <!-- pelis_vistas -->
   <div class="window" id="win-pelis" data-nombre="pelis_vistas" hidden>
-    <div class="titlebar"><span>🎬 pelis_vistas</span><button class="tb-btn" data-close aria-label="cerrar">×</button></div>
+    <div class="titlebar"><span>pelis_vistas</span><button class="tb-btn" data-close aria-label="cerrar">×</button></div>
     <div class="win-inset">
       <div class="pelis-fila" id="pelis-fila"><span style="font-size:var(--text-body);">cargando letterboxd…</span></div>
       <div class="pelis-pie"><a href="https://boxd.it/9uosP" target="_blank" rel="noopener">abrir letterboxd ↗</a></div>
@@ -83,7 +83,7 @@
 
   <!-- links -->
   <div class="window" id="win-links" data-nombre="links" hidden>
-    <div class="titlebar"><span>🔗 links</span><button class="tb-btn" data-close aria-label="cerrar">×</button></div>
+    <div class="titlebar"><span>links</span><button class="tb-btn" data-close aria-label="cerrar">×</button></div>
     <div class="win-inset">
       <div class="links-grid" id="links-grid"></div>
     </div>
@@ -91,7 +91,7 @@
 
   <!-- panel de control -->
   <div class="window" id="win-panel" data-nombre="panel_de_control" hidden>
-    <div class="titlebar"><span>🎨 panel_de_control.exe</span><button class="tb-btn" data-close aria-label="cerrar">×</button></div>
+    <div class="titlebar"><span>panel_de_control.exe</span><button class="tb-btn" data-close aria-label="cerrar">×</button></div>
     <div class="win-inset">
       <h3 style="margin:0;font-size:var(--text-heading);">Propiedades de pantalla</h3>
       <div class="monitor-preview" id="monitor-preview"></div>
@@ -134,10 +134,10 @@
 
   <!-- menú Inicio -->
   <div id="menu-inicio" hidden>
-    <button class="menu-item" data-abre="panel">🎨 panel_de_control.exe</button>
-    <button class="menu-item" data-abre="perfil">👤 perfil</button>
-    <button class="menu-item" data-abre="links">🔗 links</button>
-    <button class="menu-item" data-abre="pelis">🎬 pelis_vistas</button>
+    <button class="menu-item" data-abre="panel">panel_de_control.exe</button>
+    <button class="menu-item" data-abre="perfil">perfil</button>
+    <button class="menu-item" data-abre="links">links</button>
+    <button class="menu-item" data-abre="pelis">pelis_vistas</button>
     <button class="menu-item" id="menu-grub">⏻ volver a GRUB</button>
   </div>
 

--- a/os/os.js
+++ b/os/os.js
@@ -520,7 +520,7 @@
     '¿Sabías que el panel_de_control.exe puede cambiar el tema? Prueba "Verde fósforo".',
     'Las ventanas recuerdan dónde las dejaste. Vuelve cuando quieras.',
     'El explorador de la izquierda es el mapa del sitio. Un ✓ significa que la ventana está abierta.',
-    'Si te aburres, mira mis pelis en la ventana pelis_vistas 🎬.'
+    'Si te aburres, mira mis pelis en la ventana pelis_vistas.'
   ];
   function initAssistant() {
     var asistente = document.getElementById('asistente');


### PR DESCRIPTION
## Summary
- Elimina los emojis decorativos de `/os/index.html` y `/os/os.js` (persona, nota musical, elefante, claqueta, enlace, paleta, monitor)
- Conserva los iconos de carpeta (📁📂) y el icono de "volver a GRUB" (⏻)

## Test plan
- [ ] Abrir `/os/` en el navegador y comprobar que las ventanas, el árbol de carpetas y el menú Inicio se ven correctamente sin emojis sobrantes

🤖 Generated with [Claude Code](https://claude.com/claude-code)